### PR TITLE
Fix for "uninitialized constant Sinatra::Sprockets::Manifest"

### DIFF
--- a/lib/sinatra/asset_pipeline/task.rb
+++ b/lib/sinatra/asset_pipeline/task.rb
@@ -10,7 +10,7 @@ module Sinatra
           desc "Precompile assets"
           task :precompile do
             environment = app.sprockets
-            manifest = Sprockets::Manifest.new(environment.index, app.assets_path)
+            manifest = ::Sprockets::Manifest.new(environment.index, app.assets_path)
             manifest.compile(app.assets_precompile)
           end
 


### PR DESCRIPTION
Fixes:

```
$ rake assets:precompile
** Invoke assets:precompile (first_time)
** Execute assets:precompile
rake aborted!
uninitialized constant Sinatra::Sprockets::Manifest
…/gems/sinatra-asset-pipeline-0.2.0/lib/sinatra/asset_pipeline/task.rb:13:in `block (2 levels) in initialize'
```
