### PR TITLE
Remove erroneous comma from example setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ class App < Sinatra::Base
   set :assets_precompile, %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff)
 
   # Logical paths to your assets
-  set :assets_prefix, %w(assets, vendor/assets)
+  set :assets_prefix, %w(assets vendor/assets)
 
   # Use another host for serving assets
   set :assets_host, '<id>.cloudfront.net'


### PR DESCRIPTION
Hi Joakim,

This is the same Stefan Sobering that has been emailing. I solved my issue by adding the following to my application: 

```
set :assets_precompile, %w(application.js application.css)
```

I swear I had already tried that many times, as my filenames differ from the default 'app.js' and 'app.css', but I got it working nonetheless.

However, in my quest to get it working I read the README multiple times and noticed a very small, trivial error. There was an erroneous comma in one of the setting examples, which I removed.

Cheers
