### PR TITLE
Register module to allow sinatra-asset-pipeline work with classical apps

### DIFF
--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -67,4 +67,6 @@ module Sinatra
       self.set(key, default) unless self.respond_to? key
     end
   end
+
+  register AssetPipeline
 end


### PR DESCRIPTION
Added a required register call to enable sinatra-asset-pipeline for classical apps. Follows the advice given in http://www.sinatrarb.com/extensions.html.

Although I agree they're important, I haven't added any tests as it's a good deal of work for a one-liner. Could I suggest that we merge this, and then go about thinking of a testing strategy for classical apps?