### PR TITLE
Adds *.woff2 to default assets_precompile list

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ require 'sinatra/asset_pipeline'
 
 class App < Sinatra::Base
   # Include these files when precompiling assets
-  set :assets_precompile, %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff)
+  set :assets_precompile, %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2)
 
   # Logical paths to your assets
   set :assets_prefix, %w(assets vendor/assets)

--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -6,7 +6,7 @@ module Sinatra
   module AssetPipeline
     def self.registered(app)
       app.set_default :sprockets, Sprockets::Environment.new
-      app.set_default :assets_precompile, %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff)
+      app.set_default :assets_precompile, %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2)
       app.set_default :assets_prefix, %w(assets vendor/assets)
       app.set_default :assets_path, -> { File.join(public_folder, "assets") }
       app.set_default :assets_protocol, :http

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -5,7 +5,7 @@ describe Sinatra::AssetPipeline do
 
   describe App do
     describe "assets_precompile" do
-      it { expect(App.assets_precompile).to eq %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff) }
+      it { expect(App.assets_precompile).to eq %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2) }
     end
 
     describe "assets_prefix" do


### PR DESCRIPTION
Since WOFF 2.0 is a pretty common web font format these days, it wouldn't hurt to add it to the default assets_precompile list. Even though, I know that you can always modify the list in your own projects. 