### PR TITLE
Support absolute asset paths

### DIFF
--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require 'sprockets'
 require 'sprockets-sass'
 require 'sprockets-helpers'
@@ -22,7 +23,11 @@ module Sinatra
 
       app.configure do
         app.assets_prefix.each do |prefix|
-          paths = Dir[File.join(app.root, prefix, '*')]
+          paths = if Pathname.new(prefix).absolute?
+            Dir[File.join(prefix, '*')]
+          else
+            Dir[File.join(app.root, prefix, '*')]
+          end
           paths.each { |path| app.sprockets.append_path path }
         end
 

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -51,7 +51,7 @@ describe Sinatra::AssetPipeline do
     end
 
     describe "assets_prefix" do
-      it { expect(CustomApp.assets_prefix).to eq %w(assets, foo/bar) }
+      it { expect(CustomApp.assets_prefix).to eq %w(assets, foo/bar /home/example/assets) }
     end
 
     describe "assets_host" do
@@ -76,6 +76,12 @@ describe Sinatra::AssetPipeline do
 
     describe "assets_debug" do
       it { expect(CustomApp.assets_debug).to eq true }
+    end
+
+    it "supports absolute path_prefixes" do
+      allow(Dir).to receive(:[]).and_return(["/home/example/assets/javascripts"])
+      CustomApp.register(Sinatra::AssetPipeline)
+      expect(CustomApp.sprockets.paths).to include("/home/example/assets/javascripts")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ class App < Sinatra::Base
 end
 
 class CustomApp < Sinatra::Base
-  set :assets_prefix, %w(assets, foo/bar)
+  set :assets_prefix, %w(assets, foo/bar /home/example/assets)
   set :assets_precompile, %w(foo.css foo.js)
   set :assets_host, 'foo.cloudfront.net'
   set :assets_protocol, :https


### PR DESCRIPTION
I'm using a few packages from https://rails-assets.org. Their assets are setup in the normal Rails way (`app/assets/*`) and end up being absolute paths since they're located in the gem.

The current path resolution assumes `assets_prefix` values are all relative to the project, which isn't case here, so this just does a simple check and adjusts the glob appropriately.
