### PR TITLE
Upgrade to Sprockets 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 2.1.0
   - 2.0.0
   - 1.9.3
+before_install:
+  - gem install bundler
+

--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -1,5 +1,4 @@
 require 'sprockets'
-require 'sprockets-sass'
 require 'sprockets-helpers'
 
 module Sinatra

--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -66,6 +66,4 @@ module Sinatra
       self.set(key, default) unless self.respond_to? key
     end
   end
-
-  register AssetPipeline
 end

--- a/sinatra-asset-pipeline.gemspec
+++ b/sinatra-asset-pipeline.gemspec
@@ -13,13 +13,12 @@ Gem::Specification.new do |gem|
   gem.license = "MIT"
 
   gem.files = Dir["README.md", "lib/**/*.rb"]
-  gem.add_dependency 'rake', '~> 10.0'
+  gem.add_dependency 'rake', '~> 11.2'
   gem.add_dependency 'sinatra', '~> 1.4'
-  gem.add_dependency 'sass', '~> 3.1'
-  gem.add_dependency 'coffee-script', '~> 2.3'
-  gem.add_dependency 'sprockets', '~> 2.12'
-  gem.add_dependency 'sprockets-sass', '~> 1.2'
+  gem.add_dependency 'sass', '~> 3.4'
+  gem.add_dependency 'coffee-script', '~> 2.4'
+  gem.add_dependency 'sprockets', '~> 3.6.3'
   gem.add_dependency 'sprockets-helpers', '~> 1.1'
-  gem.add_development_dependency 'rspec', '~> 3.1'
+  gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test', '~> 0.6'
 end

--- a/spec/asset_pipeline/task_spec.rb
+++ b/spec/asset_pipeline/task_spec.rb
@@ -11,9 +11,13 @@ describe Sinatra::AssetPipeline::Task do
     it "precompiles assets" do
       Rake::Task['assets:precompile'].invoke
 
-      expect(File.exists?(Dir.glob("public/assets/manifest-*.json").first)).to be true
+      manifest_path = 'public/assets/.sprockets-manifest-*.json'
+      globbed = Dir.glob(manifest_path)
 
-      manifest = JSON.parse File.read(Dir.glob("public/assets/manifest-*.json").first)
+      expect(globbed).to_not be_empty
+      expect(File.exists?(globbed.first)).to be true
+
+      manifest = JSON.parse File.read(globbed.first)
 
       manifest["files"].each_key do |file|
         expect(File.exists?("public/assets/#{file}")).to be true

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -94,7 +94,7 @@ describe Sinatra::AssetPipeline do
     end
 
     it "serves an asset with a digest filename" do
-      get '/assets/constructocat2-b5921515627e82a923079eeaefccdbac.jpg'
+      get '/assets/constructocat2-b44344a7a501a79f5080f66bc73d7566f7ed12030819ed0baa7f0f613a65db01.jpg'
 
       expect(last_response).to be_ok
     end


### PR DESCRIPTION
This is in response to #51.

### Major Changes
- Upgrade Sprockets dependency to 3.6.3
  - Sprockets 3.7 currently has deprecation warnings for `register_engine`, and I would rather submit a resolution to that problem in a new PR. But, it could be added here if it was really wanted.
- sprockets-sass removal
  - Sprockets-sass has a hard dependency on Sprockets 2.x. There is an [issue](petebrowne/sprockets-sass) to address this, and I tried futzing around myself with it, but eventually gave up as it required more knowledge of the internals of the gem than I have. Unfortunately, the last real commit to the repo was in December 2014. I don't know how this affects the asset-pipeline itself, as I've never needed to use sprockets-sass in my projects, and without any input from the original author of sprockets-sass I don't see the issue being resolved anytime soon.

### Minor changes
- Alteration `task_spec` to load '.sprockets-manifest-\*.json' instead of 'manifest-\*.json' as the default filename changed.
- Updated conscructocat2 URI due to new digest
- Add `bundle update` to `before_install` in `.travis.yml` due to a known bug with Bundler on Travis' 1.9.3 container.
- Upgrade Rake dependency to 11.2
- Upgrade Sass dependency to 3.4
- Upgrade coffee-script dependency to 2.4