### PR TITLE
Upgrade to Sprockets 3.x take two

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 2.1.0
   - 2.0.0
   - 1.9.3
+before_install:
+  - gem install bundler
+

--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 Sinatra Asset Pipeline [![Build Status](https://travis-ci.org/kalasjocke/sinatra-asset-pipeline.svg?branch=master)](https://travis-ci.org/kalasjocke/sinatra-asset-pipeline) 
 ======================
 
-An asset pipeline implementation for Sinatra based on [Sprockets](https://github.com/sstephenson/sprockets) with support for CoffeeScript, SASS, SCSS, LESS, ERB as well as CSS (SASS, YUI) and JavaScript (uglifier, YUI, Closure) minification.
-
-sinatra-asset-pipeline supports both compiling assets on the fly for development as well as precompiling assets for production.
+An asset pipeline implementation for Sinatra based on [Sprockets](https://github.com/rails/sprockets). sinatra-asset-pipeline supports both compiling assets on the fly for development as well as precompiling assets for production. The design goal for sinatra-asset-pipeline is to provide good defaults for integrating your Sinatra application with Sprockets.
 
 # Installation
 
-Include sinatra-asset-pipeline in your project's Gemfile:
+Install Sinatra Asset Pipeline from RubyGems:
 
-```ruby
-gem 'sinatra-asset-pipeline'
+```bash
+gem install sinatra-asset-pipeline
 ```
 
-Make sure to add the sinatra-asset-pipeline Rake task in your applications `Rakefile`:
+Or, include it in your project's `Gemfile`:
+
+```ruby
+gem 'sinatra-asset-pipeline', '~> 1.0'
+```
+
+# Usage
+
+Add the provided Rake tasks to your applications `Rakefile`:
 
 ```ruby
 require 'sinatra/asset_pipeline/task'
@@ -22,38 +28,36 @@ require './app'
 Sinatra::AssetPipeline::Task.define! App
 ```
 
-If your application runs Sinatra in classic style you can define your Rake task as follows:
+This makes your application serve assets inside `assets` folder under the public `/assets` path. You can use the helpers provided by [sprocket-helpers](https://github.com/petebrowne/sprockets-helpers) inside your assets to ease locating your assets.
+
+During deployment of your application you can use `precompile` rake task to precompile your assets to serve them as static files from your applications public folder.
+
+```bash
+RACK_ENV=production rake assets:precompile
+```
+
+To leverage the Sprockets preprocessor pipeline inside your app you can use the `assets_js_compressor` and `assets_css_compressor` settings respectively. See the [Using Processors](https://github.com/rails/sprockets#using-processors) section of the Sprockets readme for details.
+
+## Classic style
+
+If your application runs Sinatra in classic style you can define your Rake tasks as follows:
 
 ```ruby
 Sinatra::AssetPipeline::Task.define! Sinatra::Application
 ```
 
-Now, when everything is in place you can precompile assets located in `assets/<asset-type>` with:
-
-```bash
-$ RACK_ENV=production rake assets:precompile
-```
-
-And remove old compiled assets with:
-
-```bash
-$ RACK_ENV=production rake assets:clean
-```
-
-# Example
+# Customization
 
 In its most simple form, you just register the `Sinatra::AssetPipeline` Sinatra extension within your application:
 
 ```ruby
-Bundler.require
-
 require 'sinatra/asset_pipeline'
 
 class App < Sinatra::Base
   register Sinatra::AssetPipeline
 
   get '/' do
-    haml :index
+    'hi'
   end
 end
 ```
@@ -61,16 +65,14 @@ end
 However, if your application doesn't follow the defaults you can customize it as follows:
 
 ```ruby
-Bundler.require
-
 require 'sinatra/asset_pipeline'
 
 class App < Sinatra::Base
   # Include these files when precompiling assets
   set :assets_precompile, %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2)
 
-  # Logical paths to your assets
   set :assets_prefix, %w(assets vendor/assets)
+  # The path to your assets
 
   # Use another host for serving assets
   set :assets_host, '<id>.cloudfront.net'
@@ -88,49 +90,7 @@ class App < Sinatra::Base
   register Sinatra::AssetPipeline
 
   get '/' do
-    haml :index
+    'hi'
   end
 end
 ```
-
-Now when everything is in place you can use all helpers provided by [sprockets-helpers](https://github.com/petebrowne/sprockets-helpers), an example:
-
-```scss
-body {
-  background-image: image-url('cat.png');
-}
-```
-
-Note that you don't need to require [sprockets-helpers](https://github.com/petebrowne/sprockets-helpers) inside your code to leverage the functionallity given to you by the integration, sinatra-asset-pipeline handles that for you.
-
-### CSS and JavaScript minification
-
-If you would like to use CSS and/or JavaScript minification make sure to require the needed gems in your `Gemfile`:
-
-<table>
-  <tr>
-    <th>Minifier</th>
-    <th>Gem</th>
-  </tr>
-  <tr>
-    <td>:sass</td>
-    <td>sass</td>
-  </tr>
-  <tr>
-    <td>:closure</td>
-    <td>closure-compiler</td>
-  </tr>
-  <tr>
-    <td>:uglifier</td>
-    <td>uglifier</td>
-  </tr>
-  <tr>
-    <td>:yui</td>
-    <td>yui-compressor</td>
-  </tr>
-</table>
-
-### Compass integration
-
-Given that we're using [sprockets-sass](https://github.com/petebrowne/sprockets-sass) under the hood we have out of the box support for [compass](https://github.com/chriseppstein/compass). Just include the compass gem in your `Gemfile` and include the compass mixins in your `app.css.scss` file.
-

--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -1,5 +1,4 @@
 require 'sprockets'
-require 'sprockets-sass'
 require 'sprockets-helpers'
 
 module Sinatra

--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -66,6 +66,4 @@ module Sinatra
       self.set(key, default) unless self.respond_to? key
     end
   end
-
-  register AssetPipeline
 end

--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -21,8 +21,7 @@ module Sinatra
 
       app.configure do
         app.assets_prefix.each do |prefix|
-          paths = Dir[File.join(app.root, prefix, '*')]
-          paths.each { |path| app.sprockets.append_path path }
+          app.sprockets.append_path File.join(app.root, prefix)
         end
 
         Sprockets::Helpers.configure do |config|

--- a/sinatra-asset-pipeline.gemspec
+++ b/sinatra-asset-pipeline.gemspec
@@ -13,13 +13,12 @@ Gem::Specification.new do |gem|
   gem.license = "MIT"
 
   gem.files = Dir["README.md", "lib/**/*.rb"]
-  gem.add_dependency 'rake', '~> 10.0'
+  gem.add_dependency 'rake', '~> 11.2'
   gem.add_dependency 'sinatra', '~> 1.4'
-  gem.add_dependency 'sass', '~> 3.1'
-  gem.add_dependency 'coffee-script', '~> 2.3'
-  gem.add_dependency 'sprockets', '~> 2.12'
-  gem.add_dependency 'sprockets-sass', '~> 1.2'
+  gem.add_dependency 'sass', '~> 3.4'
+  gem.add_dependency 'coffee-script', '~> 2.4'
+  gem.add_dependency 'sprockets', '~> 3.6.3'
   gem.add_dependency 'sprockets-helpers', '~> 1.1'
-  gem.add_development_dependency 'rspec', '~> 3.1'
+  gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test', '~> 0.6'
 end

--- a/spec/asset_pipeline/task_spec.rb
+++ b/spec/asset_pipeline/task_spec.rb
@@ -11,9 +11,13 @@ describe Sinatra::AssetPipeline::Task do
     it "precompiles assets" do
       Rake::Task['assets:precompile'].invoke
 
-      expect(File.exists?(Dir.glob("public/assets/manifest-*.json").first)).to be true
+      manifest_path = 'public/assets/.sprockets-manifest-*.json'
+      globbed = Dir.glob(manifest_path)
 
-      manifest = JSON.parse File.read(Dir.glob("public/assets/manifest-*.json").first)
+      expect(globbed).to_not be_empty
+      expect(File.exists?(globbed.first)).to be true
+
+      manifest = JSON.parse File.read(globbed.first)
 
       manifest["files"].each_key do |file|
         expect(File.exists?("public/assets/#{file}")).to be true

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -51,7 +51,7 @@ describe Sinatra::AssetPipeline do
     end
 
     describe "assets_prefix" do
-      it { expect(CustomApp.assets_prefix).to eq %w(assets, foo/bar) }
+      it { expect(CustomApp.assets_prefix).to eq %w(assets foo/bar) }
     end
 
     describe "assets_host" do

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -98,13 +98,6 @@ describe Sinatra::AssetPipeline do
 
       expect(last_response).to be_ok
     end
-
-    it "serves only the asset body with query param body=1" do
-      get '/assets/test_body_param.js?body=1'
-
-      expect(last_response).to be_ok
-      expect(last_response.body).to eq %Q[var str = "body";\n]
-    end
   end
 
   describe "path prefix" do

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -87,14 +87,14 @@ describe Sinatra::AssetPipeline do
     end
 
     it "serves an asset" do
-      get '/assets/test-_foo.css'
+      get '/assets/stylesheets/test-_foo.css'
 
       expect(last_response).to be_ok
       expect(last_response.body).to eq css_content
     end
 
     it "serves an asset with a digest filename" do
-      get '/assets/constructocat2-b44344a7a501a79f5080f66bc73d7566f7ed12030819ed0baa7f0f613a65db01.jpg'
+      get '/assets/images/constructocat2-b44344a7a501a79f5080f66bc73d7566f7ed12030819ed0baa7f0f613a65db01.jpg'
 
       expect(last_response).to be_ok
     end
@@ -115,7 +115,7 @@ describe Sinatra::AssetPipeline do
     end
 
     it "serves an asset from the specified path prefix" do
-      get '/static/test-_foo.css'
+      get '/static/stylesheets/test-_foo.css'
 
       expect(last_response).to be_ok
       expect(last_response.body).to eq css_content

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -94,7 +94,7 @@ describe Sinatra::AssetPipeline do
     end
 
     it "serves an asset with a digest filename" do
-      get '/assets/constructocat2-b5921515627e82a923079eeaefccdbac.jpg'
+      get '/assets/constructocat2-b44344a7a501a79f5080f66bc73d7566f7ed12030819ed0baa7f0f613a65db01.jpg'
 
       expect(last_response).to be_ok
     end

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -79,7 +79,7 @@ describe Sinatra::AssetPipeline do
     end
   end
 
-  describe "development environment" do
+  describe "in development environment" do
     include Rack::Test::Methods
 
     def app

--- a/spec/assets/javascripts/test_body_param.js
+++ b/spec/assets/javascripts/test_body_param.js
@@ -1,2 +1,0 @@
-//= require_tree .
-var str = "body";

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ class App < Sinatra::Base
 end
 
 class CustomApp < Sinatra::Base
-  set :assets_prefix, %w(assets, foo/bar)
+  set :assets_prefix, %w(assets foo/bar)
   set :assets_precompile, %w(foo.css foo.js)
   set :assets_host, 'foo.cloudfront.net'
   set :assets_protocol, :https


### PR DESCRIPTION
This pull request builds on top of #57. 

It seems that this was all it took was to update to Sprockets 3.x now when all dependencies was in place. Sorry it took so long, I just haven't had the possibility to focus on this project for a while. From now on I'll try to be more responsive when it comes to maintaining this gem.

Fixes #51. Closes #57.