### PR TITLE
Rename config options to be more desciptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,14 @@ class App < Sinatra::Base
   # Include these files when precompiling assets
   set :assets_precompile, %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2)
 
-  set :assets_prefix, %w(assets vendor/assets)
   # The path to your assets
+  set :assets_paths, %w(assets)
 
   # Use another host for serving assets
   set :assets_host, '<id>.cloudfront.net'
+
+  # Which prefix to serve the assets under
+  set :assets_prefix, 'custom-prefix'
 
   # Serve assets using this protocol (http, :https, :relative)
   set :assets_protocol, :http

--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -5,37 +5,37 @@ module Sinatra
   module AssetPipeline
     def self.registered(app)
       app.set_default :sprockets, Sprockets::Environment.new
+      app.set_default :assets_paths, %w(assets)
       app.set_default :assets_precompile, %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2)
-      app.set_default :assets_prefix, %w(assets vendor/assets)
-      app.set_default :assets_path, -> { File.join(public_folder, "assets") }
+      app.set_default :assets_public_path, -> { File.join(public_folder, "assets") }
       app.set_default :assets_protocol, :http
       app.set_default :assets_css_compressor, nil
       app.set_default :assets_js_compressor, nil
       app.set_default :assets_host, nil
+      app.set_default :assets_prefix, '/assets'
       app.set_default :assets_digest, true
       app.set_default :assets_debug, false
-      app.set_default :path_prefix, nil
 
       app.set :static, :true
       app.set :static_cache_control, [:public, :max_age => 60 * 60 * 24 * 365]
 
       app.configure do
-        app.assets_prefix.each do |prefix|
-          app.sprockets.append_path File.join(app.root, prefix)
+        app.assets_paths.each do |path|
+          app.sprockets.append_path File.join(app.root, path)
         end
 
         Sprockets::Helpers.configure do |config|
           config.environment = app.sprockets
           config.digest = app.assets_digest
-          config.prefix = app.path_prefix unless app.path_prefix.nil?
+          config.prefix = app.assets_prefix unless app.assets_prefix.nil?
           config.debug = app.assets_debug
         end
       end
 
       app.configure :staging, :production do
         Sprockets::Helpers.configure do |config|
-          config.manifest = Sprockets::Manifest.new(app.sprockets, app.assets_path)
-          config.prefix = app.path_prefix unless app.path_prefix.nil?
+          config.manifest = Sprockets::Manifest.new(app.sprockets, app.assets_public_path)
+          config.prefix = app.assets_prefix unless app.assets_prefix.nil?
         end
       end
 
@@ -46,14 +46,14 @@ module Sinatra
         Sprockets::Helpers.configure do |config|
           config.protocol = app.assets_protocol
           config.asset_host = app.assets_host unless app.assets_host.nil?
-          config.prefix = app.path_prefix unless app.path_prefix.nil?
+          config.prefix = app.assets_prefix unless app.assets_prefix.nil?
         end
       end
 
       app.helpers Sprockets::Helpers
 
       app.configure :test, :development do
-        app.get "#{Sprockets::Helpers.prefix}/*" do |path|
+        app.get "#{app.assets_prefix}/*" do |path|
           env_sprockets = request.env.dup
           env_sprockets['PATH_INFO'] = path
           settings.sprockets.call env_sprockets

--- a/lib/sinatra/asset_pipeline/task.rb
+++ b/lib/sinatra/asset_pipeline/task.rb
@@ -10,13 +10,13 @@ module Sinatra
           desc "Precompile assets"
           task :precompile do
             environment = app_klass.sprockets
-            manifest = Sprockets::Manifest.new(environment.index, app_klass.assets_path)
+            manifest = Sprockets::Manifest.new(environment.index, app_klass.assets_public_path)
             manifest.compile(app_klass.assets_precompile)
           end
 
           desc "Clean assets"
           task :clean do
-            FileUtils.rm_rf(app_klass.assets_path)
+            FileUtils.rm_rf(app_klass.assets_public_path)
           end
         end
       end

--- a/lib/sinatra/asset_pipeline/version.rb
+++ b/lib/sinatra/asset_pipeline/version.rb
@@ -1,5 +1,5 @@
 module Sinatra
   module AssetPipeline
-    VERSION = '0.7.0'
+    VERSION = '1.0.0'
   end
 end

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -8,8 +8,8 @@ describe Sinatra::AssetPipeline do
       it { expect(App.assets_precompile).to eq %w(app.js app.css *.png *.jpg *.svg *.eot *.ttf *.woff *.woff2) }
     end
 
-    describe "assets_prefix" do
-      it { expect(App.assets_prefix).to eq %w(assets) }
+    describe "assets_paths" do
+      it { expect(App.assets_paths).to eq %w(assets) }
     end
 
     describe "assets_host" do
@@ -28,10 +28,6 @@ describe Sinatra::AssetPipeline do
       it { expect(App.sprockets.js_compressor).to be nil }
     end
 
-    describe "assets_path_prefix" do
-      it { expect(App.path_prefix).to be nil }
-    end
-
     describe "assets_digest" do
       it { expect(App.assets_digest).to be true }
     end
@@ -40,8 +36,8 @@ describe Sinatra::AssetPipeline do
       it { expect(App.assets_debug).to be false }
     end
 
-    describe "path_prefix" do
-      it { expect(App.path_prefix).to be nil }
+    describe "assets_prefix" do
+      it { expect(App.assets_prefix).to eq '/assets' }
     end
   end
 
@@ -50,8 +46,8 @@ describe Sinatra::AssetPipeline do
       it { expect(CustomApp.assets_precompile).to eq %w(foo.css foo.js) }
     end
 
-    describe "assets_prefix" do
-      it { expect(CustomApp.assets_prefix).to eq %w(assets foo/bar) }
+    describe "assets_paths" do
+      it { expect(CustomApp.assets_paths).to eq %w(assets foo/bar) }
     end
 
     describe "assets_host" do
@@ -70,8 +66,8 @@ describe Sinatra::AssetPipeline do
       it { expect(CustomApp.sprockets.js_compressor).to eq Sprockets::UglifierCompressor }
     end
 
-    describe "assets_path_prefix" do
-      it { expect(CustomApp.path_prefix).to eq '/static' }
+    describe "assets_prefix" do
+      it { expect(CustomApp.assets_prefix).to eq '/static' }
     end
 
     describe "assets_debug" do
@@ -107,7 +103,7 @@ describe Sinatra::AssetPipeline do
       PrefixApp
     end
 
-    it "serves an asset from the specified path prefix" do
+    it "serves an asset from the specified asset prefix" do
       get '/static/stylesheets/test-_foo.css'
 
       expect(last_response).to be_ok

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,26 +11,24 @@ RSpec.configure do |config|
 end
 
 class App < Sinatra::Base
-  set :assets_prefix, %w(assets)
   register Sinatra::AssetPipeline
 end
 
 class CustomApp < Sinatra::Base
-  set :assets_prefix, %w(assets foo/bar)
+  set :assets_paths, %w(assets foo/bar)
   set :assets_precompile, %w(foo.css foo.js)
   set :assets_host, 'foo.cloudfront.net'
   set :assets_protocol, :https
   set :environment, :production
   set :assets_css_compressor, :sass
   set :assets_js_compressor, :uglifier
-  set :path_prefix, "/static"
+  set :assets_prefix, "/static"
   set :assets_debug, true
   register Sinatra::AssetPipeline
 end
 
 class PrefixApp < Sinatra::Base
-  set :assets_prefix, %w(assets)
-  set :path_prefix, "/static"
+  set :assets_prefix, "/static"
   register Sinatra::AssetPipeline
 end
 


### PR DESCRIPTION
This pull request changes a few names of the settings. The semantic mening is still the same, it's just that the name change to better reflect what they do. Since this is a breaking change I've updated the major version to 1.0.0. Yay for major release 🎉 

`asset_path` -> `assets_public_path`
`asset_prefix` -> `assets_paths`
`path_prefix` -> `assets_prefix`

The most confusing one to be aware of is the change of `assets_prefix`, since that one changes meaning when this pull request is merged.