### PR TITLE
fix namespacing issue with Sprockets::Manifest

### DIFF
--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -34,7 +34,7 @@ module Sinatra
 
       app.configure :staging, :production do
         ::Sprockets::Helpers.configure do |config|
-          config.manifest = Sprockets::Manifest.new(app.sprockets, app.assets_public_path)
+          config.manifest = ::Sprockets::Manifest.new(app.sprockets, app.assets_public_path)
           config.prefix = app.assets_prefix unless app.assets_prefix.nil?
         end
       end

--- a/lib/sinatra/asset_pipeline/task.rb
+++ b/lib/sinatra/asset_pipeline/task.rb
@@ -10,7 +10,7 @@ module Sinatra
           desc "Precompile assets"
           task :precompile do
             environment = app_klass.sprockets
-            manifest = Sprockets::Manifest.new(environment.index, app_klass.assets_public_path)
+            manifest = ::Sprockets::Manifest.new(environment.index, app_klass.assets_public_path)
             manifest.compile(app_klass.assets_precompile)
           end
 


### PR DESCRIPTION
I was seeing the following error when running in production:

```
NameError: uninitialized constant Sinatra::Sprockets::Manifest
```

Adding the explicit `::` forced it to use `Sprockets::Manifest` rather than searching for it under the `Sinatra::` namespace.