### PR TITLE
Update to sinatra 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.1.0
-  - 2.0.0
-  - 1.9.3
+  - 2.5.0
+  - 2.4.3
+  - 2.3.6
+  - 2.2.9
 before_install:
   - gem install bundler
 

--- a/sinatra-asset-pipeline.gemspec
+++ b/sinatra-asset-pipeline.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |gem|
   gem.license = "MIT"
 
   gem.files = Dir["README.md", "lib/**/*.rb"]
-  gem.add_dependency 'rake', '~> 11.2'
-  gem.add_dependency 'sinatra', '~> 1.4'
-  gem.add_dependency 'sass', '~> 3.4'
+  gem.add_dependency 'rake', '~> 12.3'
+  gem.add_dependency 'sinatra', '~> 2.0'
+  gem.add_dependency 'sass', '~> 3.5'
   gem.add_dependency 'coffee-script', '~> 2.4'
-  gem.add_dependency 'sprockets', '~> 3.6'
-  gem.add_dependency 'sprockets-helpers', '~> 1.1'
-  gem.add_development_dependency 'rspec', '~> 3.5'
-  gem.add_development_dependency 'rack-test', '~> 0.6'
+  gem.add_dependency 'sprockets', '~> 3.7'
+  gem.add_dependency 'sprockets-helpers', '~> 1.2'
+  gem.add_development_dependency 'rspec', '~> 3.7'
+  gem.add_development_dependency 'rack-test', '~> 0.8'
 end


### PR DESCRIPTION
Hey Joakim,

since the old pull request (supporting sinatra 2.0.0.beta) has not been merged yet.

I made a new pull request which updates to sinatra 2.0.0. Also rake, sass, sprockets and rspec
dependencies have been updated to current versions. Travis ruby versions were set
to 2.5.0, 2.4.3, 2.3.6 and 2.2.9, matching the currently maintained ruby versions.

Any thoughts? 

Best
Martin

Closes #65 
  