### PR TITLE
Refactor rake task to implement #clean and #clobber based on Rake::SprocketsTask

### DIFF
--- a/lib/sinatra/asset_pipeline/task.rb
+++ b/lib/sinatra/asset_pipeline/task.rb
@@ -1,28 +1,52 @@
 require 'rake'
-require 'rake/tasklib'
 require 'rake/sprocketstask'
+require 'sprockets'
 
 module Sinatra
   module AssetPipeline
-    class Task < Rake::TaskLib
-      def initialize(app_klass)
+    class Task < Rake::SprocketsTask
+      attr_accessor :app
+
+      def initialize(app = nil)
+        self.app = app
+        super()
+      end
+
+      def environment
+        app ? app.sprockets : super
+      end
+
+      def assets
+        app ? app.assets_precompile : super
+      end
+
+      def manifest
+        app ? Sprockets::Manifest.new(environment.index, app.assets_public_path) : super
+      end
+
+      def define
         namespace :assets do
-          desc "Precompile assets"
+          %w( precompile clean clobber ).each { |task| Rake::Task[task].clear if Rake::Task.task_defined?(task) }
+
+          desc "Compile all assets"
           task :precompile do
-            environment = app_klass.sprockets
-            manifest = ::Sprockets::Manifest.new(environment.index, app_klass.assets_public_path)
-            manifest.compile(app_klass.assets_precompile)
+            manifest.compile(assets)
           end
 
-          desc "Clean assets"
-          task :clean do
-            FileUtils.rm_rf(app_klass.assets_public_path)
+          desc "Remove old compiled assets"
+          task :clean, [:keep] do |t, args|
+            manifest.clean(Integer(args.keep || self.keep))
+          end
+
+          desc "Remove compiled assets"
+          task :clobber do
+            manifest.clobber
           end
         end
       end
 
-      def self.define!(app_klass)
-        self.new app_klass
+      def self.define!(app)
+        self.new(app)
       end
     end
   end

--- a/lib/sinatra/asset_pipeline/task.rb
+++ b/lib/sinatra/asset_pipeline/task.rb
@@ -30,17 +30,23 @@ module Sinatra
 
           desc "Compile all assets"
           task :precompile do
-            manifest.compile(assets)
+            with_logger do
+              manifest.compile(assets)
+            end
           end
 
           desc "Remove old compiled assets"
           task :clean, [:keep] do |t, args|
-            manifest.clean(Integer(args.keep || self.keep))
+            with_logger do
+              manifest.clean(Integer(args.keep || self.keep))
+            end
           end
 
           desc "Remove compiled assets"
           task :clobber do
-            manifest.clobber
+            with_logger do
+              manifest.clobber
+            end
           end
         end
       end

--- a/spec/asset_pipeline/task_spec.rb
+++ b/spec/asset_pipeline/task_spec.rb
@@ -6,8 +6,8 @@ describe Sinatra::AssetPipeline::Task do
   include_context "assets"
 
   before(:all) { Dir.chdir "spec" }
-
-  let(:manifest) do
+  
+  let(:json_manifest) do
     manifest_path = 'public/assets/.sprockets-manifest-*.json'
     globbed = Dir.glob(manifest_path)
     JSON.parse File.read(globbed.first)
@@ -17,11 +17,11 @@ describe Sinatra::AssetPipeline::Task do
     before { Rake::Task['assets:precompile'].invoke }
 
     it "generates a manifest" do
-      expect(manifest).not_to be_empty
+      expect(json_manifest).not_to be_empty
     end
 
     it "precompiles assets" do
-      manifest["files"].each_key do |file|
+      json_manifest["files"].each_key do |file|
         expect(File.exists?("public/assets/#{file}")).to be true
         expect(File.read("public/assets/#{file}")).to eq js_content  if file.end_with? '.js'
         expect(File.read("public/assets/#{file}")).to eq css_content if file.end_with? '.css'
@@ -32,8 +32,8 @@ describe Sinatra::AssetPipeline::Task do
   describe "assets:clean" do
     before { Rake::Task['assets:precompile'].invoke }
 
-    context 'with default keep of 2' do
-      it "cleans precompiled assets" do
+    context 'with default keep' do
+      it "removes only outdated compiled assets" do
         Rake::Task['assets:clean'].invoke
 
         expect(Dir['public/assets']).not_to be_empty

--- a/spec/asset_pipeline/task_spec.rb
+++ b/spec/asset_pipeline/task_spec.rb
@@ -7,18 +7,20 @@ describe Sinatra::AssetPipeline::Task do
 
   before(:all) { Dir.chdir "spec" }
 
+  let(:manifest) do
+    manifest_path = 'public/assets/.sprockets-manifest-*.json'
+    globbed = Dir.glob(manifest_path)
+    JSON.parse File.read(globbed.first)
+  end
+
   describe "assets:precompile" do
+    before { Rake::Task['assets:precompile'].invoke }
+
+    it "generates a manifest" do
+      expect(manifest).not_to be_empty
+    end
+
     it "precompiles assets" do
-      Rake::Task['assets:precompile'].invoke
-
-      manifest_path = 'public/assets/.sprockets-manifest-*.json'
-      globbed = Dir.glob(manifest_path)
-
-      expect(globbed).to_not be_empty
-      expect(File.exists?(globbed.first)).to be true
-
-      manifest = JSON.parse File.read(globbed.first)
-
       manifest["files"].each_key do |file|
         expect(File.exists?("public/assets/#{file}")).to be true
         expect(File.read("public/assets/#{file}")).to eq js_content  if file.end_with? '.js'
@@ -28,9 +30,23 @@ describe Sinatra::AssetPipeline::Task do
   end
 
   describe "assets:clean" do
-    it "cleans precompiled assets" do
-      Rake::Task['assets:clean'].invoke
+    before { Rake::Task['assets:precompile'].invoke }
 
+    context 'with default keep of 2' do
+      it "cleans precompiled assets" do
+        Rake::Task['assets:clean'].invoke
+
+        expect(Dir['public/assets']).not_to be_empty
+      end
+    end
+  end
+
+  describe "assets:clopper" do
+    before { Rake::Task['assets:precompile'].invoke }
+
+    it 'removes all compiled assets' do
+      expect(Dir['public/assets']).not_to be_empty
+      Rake::Task['assets:clobber'].invoke
       expect(Dir['public/assets']).to be_empty
     end
   end


### PR DESCRIPTION
Since v2 sprockets differentiates between a clean and a clobber rake task:

clean     -> remove "outdated" precompiled assets only (based on keep or time param)
clobber -> remove all precompiled assets

Currently the sinatra-asset-pipelines clean task implements the "clobber" behaviour, 
missing a smart way to clean up assets in production without swiping all files ... 

By inheriting from the Rake::Sprockets::Task both behaviours can be easily supported.


