### PR TITLE
Allow to specify custom ENVs to mirror staging and production

### DIFF
--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -15,6 +15,7 @@ module Sinatra
       app.set_default :assets_prefix, '/assets'
       app.set_default :assets_digest, true
       app.set_default :assets_debug, false
+      app.set_default :precompiled_environments, %i(staging production)
 
       app.set :static, :true
       app.set :static_cache_control, [:public, :max_age => 60 * 60 * 24 * 365]
@@ -32,14 +33,14 @@ module Sinatra
         end
       end
 
-      app.configure :staging, :production do
+      app.configure(*app.precompiled_environments) do
         ::Sprockets::Helpers.configure do |config|
           config.manifest = ::Sprockets::Manifest.new(app.sprockets, app.assets_public_path)
           config.prefix = app.assets_prefix unless app.assets_prefix.nil?
         end
       end
 
-      app.configure :staging, :production do
+      app.configure(*app.precompiled_environments) do
         app.sprockets.css_compressor = app.assets_css_compressor unless app.assets_css_compressor.nil?
         app.sprockets.js_compressor = app.assets_js_compressor unless app.assets_js_compressor.nil?
 

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -39,6 +39,10 @@ describe Sinatra::AssetPipeline do
     describe "assets_prefix" do
       it { expect(App.assets_prefix).to eq '/assets' }
     end
+
+    describe "precompiled_environments" do
+      it { expect(App.precompiled_environments).to eq %i(staging production) }
+    end
   end
 
   describe CustomApp do
@@ -72,6 +76,10 @@ describe Sinatra::AssetPipeline do
 
     describe "assets_debug" do
       it { expect(CustomApp.assets_debug).to eq true }
+    end
+
+    describe "precompiled_environments" do
+      it { expect(CustomApp.precompiled_environments).to eq %i(staging uat production) }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ class CustomApp < Sinatra::Base
   set :assets_js_compressor, :uglifier
   set :assets_prefix, "/static"
   set :assets_debug, true
+  set :precompiled_environments, %i(staging uat production)
   register Sinatra::AssetPipeline
 end
 


### PR DESCRIPTION
# Background
In our application we have a custom `uat` environment and we would like it to behave like staging and production.

# Solution
Allow apps to manually specify environments that use precompiled assets. 