### PR TITLE
Support absolute assets_paths

### DIFF
--- a/lib/sinatra/asset_pipeline.rb
+++ b/lib/sinatra/asset_pipeline.rb
@@ -22,7 +22,7 @@ module Sinatra
 
       app.configure do
         app.assets_paths.each do |path|
-          app.sprockets.append_path File.join(app.root, path)
+          app.sprockets.append_path(Pathname.new(path).absolute? ? path : File.join(app.root, path))
         end
 
         ::Sprockets::Helpers.configure do |config|

--- a/spec/asset_pipeline_spec.rb
+++ b/spec/asset_pipeline_spec.rb
@@ -51,7 +51,17 @@ describe Sinatra::AssetPipeline do
     end
 
     describe "assets_paths" do
-      it { expect(CustomApp.assets_paths).to eq %w(assets foo/bar) }
+      it { expect(CustomApp.assets_paths).to eq %w(assets foo/bar /some/path/to/a/third-party/gem) }
+
+      context 'sprockets assets paths' do
+        let(:sprockets_root_path) { CustomApp.sprockets.root }
+
+        it "returns two app specific assets paths and one absolute third party assets paths" do
+          expect(CustomApp.sprockets.paths).to include(File.join(sprockets_root_path, 'spec/assets'))
+          expect(CustomApp.sprockets.paths).to include(File.join(sprockets_root_path, 'spec/foo/bar'))
+          expect(CustomApp.sprockets.paths).to include('/some/path/to/a/third-party/gem')
+        end
+      end
     end
 
     describe "assets_host" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ class App < Sinatra::Base
 end
 
 class CustomApp < Sinatra::Base
-  set :assets_paths, %w(assets foo/bar)
+  set :assets_paths, %w(assets foo/bar /some/path/to/a/third-party/gem)
   set :assets_precompile, %w(foo.css foo.js)
   set :assets_host, 'foo.cloudfront.net'
   set :assets_protocol, :https


### PR DESCRIPTION
This PR fixes #71 by enabling the sinatra-asset-pipeline to load assets_paths from gems or other external sources via absolute assets_paths.