### PR TITLE
Fix for `NameError: uninitialized constant Sinatra::Sprockets::Manifest`

### DIFF
--- a/lib/sinatra/asset_pipeline/task.rb
+++ b/lib/sinatra/asset_pipeline/task.rb
@@ -21,7 +21,7 @@ module Sinatra
       end
 
       def manifest
-        app ? Sprockets::Manifest.new(environment.index, app.assets_public_path) : super
+        app ? ::Sprockets::Manifest.new(environment.index, app.assets_public_path) : super
       end
 
       def define


### PR DESCRIPTION
Solves #70. I was also experiencing this issue. Adding the `::` fixed this. Same fix as per another older issue.